### PR TITLE
Fix/k8s api cors config

### DIFF
--- a/src/main/java/org/example/term_pj/config/SecurityConfig.java
+++ b/src/main/java/org/example/term_pj/config/SecurityConfig.java
@@ -62,8 +62,7 @@ public class SecurityConfig {
             .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler))
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth ->
-                    auth.requestMatchers("/login", "/signup").permitAll()  // 로그인과 회원가입 엔드포인트 허용
-                            .requestMatchers("/", "/index.html", "/css/**", "/js/**").permitAll()
+                    auth.requestMatchers("/api/auth/login", "/api/auth/signup").permitAll()  // 로그인과 회원가입 엔드포인트 허용
                             .requestMatchers("/predict/demo").permitAll() // 데모용 엔드포인트는 인증 불필요
 //                            .requestMatchers("/user").authenticated()
                             .anyRequest().authenticated()
@@ -78,11 +77,19 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000")); // 프론트엔드 URL
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        // CORS 설정 확장 - 다양한 프론트엔드 접근 허용
+        configuration.setAllowedOriginPatterns(Arrays.asList(
+            "http://ms-frontend.ms-frontend.*.sslip.io", 
+            "https://ms-frontend.ms-frontend.*.sslip.io",
+            "http://*.sslip.io",
+            "https://*.sslip.io"
+        ));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true);
-        
+        configuration.setMaxAge(3600L);
+       
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/src/main/java/org/example/term_pj/controller/AuthController.java
+++ b/src/main/java/org/example/term_pj/controller/AuthController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/")
+@RequestMapping("/api/auth")
 public class AuthController {
     private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
 

--- a/src/main/java/org/example/term_pj/controller/UserController.java
+++ b/src/main/java/org/example/term_pj/controller/UserController.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/user")
+@RequestMapping("/api/user")
 public class UserController {
 
     private final UserService userService;


### PR DESCRIPTION
### 1. 쿠버네티스 환경에 맞게 CORS 설정 변겅
- http://ms-frontend.ms-frontend.*.sslip.io의 형식에 맞는 요청만 가능하도록 변경
- 기존 /login, /signup 요청을 허용하던 것에서 /api/auth/login, /api/auth/signup 요청을 허용하도록 변경하였습니다.

### 2. @RequestMapping path를 frontend의 요청에 맞게 변경
- Controller의 @RequestMapping path를 /api/ 아래에 오도록 수정하였습니다.